### PR TITLE
#2 - Added validation to host and path format.

### DIFF
--- a/simple_api_client/simple_api_client.py
+++ b/simple_api_client/simple_api_client.py
@@ -48,6 +48,22 @@ class ApiResponse:
         return f"Response: {self.status_code}, {self.data}"
 
 
+class ApiClientHostError(Exception):
+    """
+    Raised when the host has a bad format.
+    """
+
+    pass
+
+
+class ApiClientPathError(Exception):
+    """
+    Raised when a path has a bad format.
+    """
+
+    pass
+
+
 class ApiClient:
     def __init__(
         self,
@@ -66,7 +82,7 @@ class ApiClient:
         :param retry_attempts: The amount of times to attempt to retry.
         :param retry_backoff_factor: A multipler to increase the time between retries by.
         :param retry_on_status: Retry on encountering these status codes.
-        :raises: Exception: If the host contains a path.
+        :raises: ApiClientHostError: If the host contains a path.
         """
         self._set_host(host)
         self._logger: Logger = logger
@@ -157,7 +173,7 @@ class ApiClient:
         :param retry_backoff_factor: A multipler to increase the time between retries by.
         :param retry_on_status: Retry on encountering these status codes.
         :return: The response converted from Json to a dict
-        :raises: Exception: If the path doesn't start with a forward-slash.
+        :raises: ApiClientPathError: If the path doesn't start with a forward-slash.
         """
         full_url = self._create_full_url(path)
         headers = self._headers
@@ -191,7 +207,7 @@ class ApiClient:
         :param retry_backoff_factor: A multipler to increase the time between retries by.
         :param retry_on_status: Retry on encountering these status codes.
         :return: The response is a binary object
-        :raises: Exception: If the path doesn't start with a forward-slash.
+        :raises: ApiClientPathError: If the path doesn't start with a forward-slash.
         """
         full_url = self._create_full_url(path)
         headers = self._headers
@@ -229,7 +245,7 @@ class ApiClient:
         :param retry_backoff_factor: A multipler to increase the time between retries by.
         :param retry_on_status: Retry on encountering these status codes.
         :return: The response as a dict.
-        :raises: Exception: If the path doesn't start with a forward-slash.
+        :raises: ApiClientPathError: If the path doesn't start with a forward-slash.
         """
         full_url = self._create_full_url(path)
         headers = self._headers
@@ -265,11 +281,11 @@ class ApiClient:
         """
         Set a correct base host for the client.
         :param host: The host to set.
-        :raises: Exception: If the host contains a path.
+        :raises: ApiClientHostError: If the host contains a path.
         """
         url = urlparse(host)
         if url.path:
-            raise Exception("No path should be specified on the host")
+            raise ApiClientHostError("No path should be specified on the host")
         self._host = f"{url.scheme}://{url.netloc}"
 
     def _create_full_url(self, path) -> str:
@@ -277,10 +293,10 @@ class ApiClient:
         Create and return the full url based on the passed path.
         :param path: The path to append to the host.
         :return: The full url.
-        :raises: Exception: If the path doesn't start with a forward-slash.
+        :raises: ApiClientPathError: If the path doesn't start with a forward-slash.
         """
         if path[0] != "/":
-            raise Exception("Path needs to start with a forward-slash")
+            raise ApiClientPathError("Path needs to start with a forward-slash")
         return f"{self._host}{path}"
 
     def _create_session(

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -25,6 +25,17 @@ class TestApiClient:
         assert client._headers == {}
         assert client._cookies == {}
 
+    def test_instantiation_with_long_host(self):
+        logger = Logger("test", level="DEBUG")
+        client = ApiClient("http://gary@www.example.com:455", logger)
+        assert client._host == "http://gary@www.example.com:455"
+
+    def test_instantiation_with_host_containing_a_path(self):
+        with pytest.raises(Exception) as excinfo:
+            logger = Logger("test", level="DEBUG")
+            client = ApiClient("http://www.example.com/url", logger)
+        assert str(excinfo.value) == "No path should be specified on the host"
+
     def test_adding_and_removing_headers(self):
         client = ApiClient("http://www.example.com", Logger("test", level="DEBUG"))
         assert client._headers == {}
@@ -124,6 +135,12 @@ class TestApiClient:
         assert session.adapters.get("https://").max_retries.backoff_factor == 0.2
         assert session.adapters.get("https://").max_retries.status_forcelist == [500]
 
+    def test_making_a_get_request_with_a_bad_path(self):
+        with pytest.raises(Exception) as excinfo:
+            client = ApiClient("http://www.example.com", Logger("test", level="DEBUG"))
+            response = client.get("unknown/resource/")
+        assert str(excinfo.value) == "Path needs to start with a forward-slash"
+
     @mock.patch("requests.Session.get")
     @mock.patch("simple_api_client.ApiClient._create_session")
     def test_making_a_get_request(self, create_session_method, requests_get_method):
@@ -144,6 +161,12 @@ class TestApiClient:
             cookies={},
             timeout=30,
         )
+
+    def test_making_a_get_binary_request_with_a_bad_path(self):
+        with pytest.raises(Exception) as excinfo:
+            client = ApiClient("http://www.example.com", Logger("test", level="DEBUG"))
+            response = client.get_binary("unknown/resource/")
+        assert str(excinfo.value) == "Path needs to start with a forward-slash"
 
     @mock.patch("requests.Session.get")
     @mock.patch("simple_api_client.ApiClient._create_session")
@@ -167,6 +190,12 @@ class TestApiClient:
             cookies={},
             timeout=30,
         )
+
+    def test_making_a_post_request_with_a_bad_path(self):
+        with pytest.raises(Exception) as excinfo:
+            client = ApiClient("http://www.example.com", Logger("test", level="DEBUG"))
+            response = client.post("unknown/resource/", {"foo": "bar"})
+        assert str(excinfo.value) == "Path needs to start with a forward-slash"
 
     @mock.patch("requests.Session.post")
     @mock.patch("simple_api_client.ApiClient._create_session")

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -5,6 +5,7 @@ import requests
 from freezegun import freeze_time
 from logging import Logger
 from simple_api_client import ApiClient, ApiResponse
+from simple_api_client.simple_api_client import ApiClientHostError, ApiClientPathError
 from urllib3.util.retry import Retry
 from werkzeug.exceptions import TooManyRequests
 
@@ -31,7 +32,7 @@ class TestApiClient:
         assert client._host == "http://gary@www.example.com:455"
 
     def test_instantiation_with_host_containing_a_path(self):
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(ApiClientHostError) as excinfo:
             logger = Logger("test", level="DEBUG")
             client = ApiClient("http://www.example.com/url", logger)
         assert str(excinfo.value) == "No path should be specified on the host"
@@ -136,7 +137,7 @@ class TestApiClient:
         assert session.adapters.get("https://").max_retries.status_forcelist == [500]
 
     def test_making_a_get_request_with_a_bad_path(self):
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(ApiClientPathError) as excinfo:
             client = ApiClient("http://www.example.com", Logger("test", level="DEBUG"))
             response = client.get("unknown/resource/")
         assert str(excinfo.value) == "Path needs to start with a forward-slash"
@@ -163,7 +164,7 @@ class TestApiClient:
         )
 
     def test_making_a_get_binary_request_with_a_bad_path(self):
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(ApiClientPathError) as excinfo:
             client = ApiClient("http://www.example.com", Logger("test", level="DEBUG"))
             response = client.get_binary("unknown/resource/")
         assert str(excinfo.value) == "Path needs to start with a forward-slash"
@@ -192,7 +193,7 @@ class TestApiClient:
         )
 
     def test_making_a_post_request_with_a_bad_path(self):
-        with pytest.raises(Exception) as excinfo:
+        with pytest.raises(ApiClientPathError) as excinfo:
             client = ApiClient("http://www.example.com", Logger("test", level="DEBUG"))
             response = client.post("unknown/resource/", {"foo": "bar"})
         assert str(excinfo.value) == "Path needs to start with a forward-slash"


### PR DESCRIPTION
The client now raises an exception if the host or any path is the wrong format. This is too avoid confusion and to make code clearer at the call site.